### PR TITLE
Update Commit to # 4594

### DIFF
--- a/src/gui/game/GameController.cpp
+++ b/src/gui/game/GameController.cpp
@@ -331,7 +331,7 @@ void GameController::PlaceSave(ui::Point position)
 		{
 			gameModel->SetPaused(placeSave->paused | gameModel->GetPaused());
 			// if this is a clipboard and there is no author info, don't do anything
-			if (Client::Ref().IsAuthorsEmpty() || placeSave->authors["type"] != "clipboard")
+			if (placeSave->authors.size() && (Client::Ref().IsAuthorsEmpty() || placeSave->authors["type"] != "clipboard"))
 				Client::Ref().MergeStampAuthorInfo(placeSave->authors);
 		}
 	}

--- a/src/lua/LegacyLuaAPI.cpp
+++ b/src/lua/LegacyLuaAPI.cpp
@@ -32,8 +32,6 @@ int luacon_partread(lua_State* l)
 
 	if (i < 0 || i >= NPART)
 		return luaL_error(l, "Out of range");
-	if (!luacon_sim->parts[i].type)
-		return luaL_error(l, "dead particle");
 	if (offset == -1)
 	{
 		if (!key.compare("id"))
@@ -71,7 +69,7 @@ int luacon_partwrite(lua_State* l)
 	if (i < 0 || i >= NPART)
 		return luaL_error(l, "Out of range");
 	if (!luacon_sim->parts[i].type)
-		return luaL_error(l, "dead particle");
+		return luaL_error(l, "Dead particle");
 	if (offset == -1)
 		return luaL_error(l, "Invalid property");
 
@@ -94,16 +92,8 @@ int luacon_partwrite(lua_State* l)
 int luacon_partsread(lua_State* l)
 {
 	int i = luaL_optinteger(l, 2, 0);
-
-	if (i<0 || i>=NPART)
-	{
+	if (i < 0 || i >= NPART)
 		return luaL_error(l, "array index out of bounds");
-	}
-	
-	if (!luacon_sim->parts[i].type)
-	{
-		return luaL_error(l, "dead particle");
-	}
 
 	lua_rawgeti(l, LUA_REGISTRYINDEX, tptPart);
 	cIndex = i;


### PR DESCRIPTION
tpt.parts: only prevent writing to dead particles, not reading
don't add null stuff when loading old stamps without author info